### PR TITLE
feat: add goto turn application

### DIFF
--- a/lib/domain/usecases/apply_turn_goto.dart
+++ b/lib/domain/usecases/apply_turn_goto.dart
@@ -1,0 +1,52 @@
+import 'package:open_adventure/domain/entities/game.dart';
+import 'package:open_adventure/domain/repositories/adventure_repository.dart';
+import 'package:open_adventure/domain/services/motion_canonicalizer.dart';
+import 'package:open_adventure/domain/value_objects/command.dart';
+import 'package:open_adventure/domain/value_objects/turn_result.dart';
+
+/// ApplyTurnGoto — applique une commande de déplacement `goto`.
+///
+/// Recherche une règle de voyage correspondant au verbe canonique et à la
+/// destination indiquée, puis met à jour l'état de jeu en conséquence.
+class ApplyTurnGoto {
+  final AdventureRepository _repo;
+  final MotionCanonicalizer _motion;
+
+  /// Crée un use case [`ApplyTurnGoto`].
+  const ApplyTurnGoto(this._repo, this._motion);
+
+  /// Applique un déplacement vers une destination.
+  ///
+  /// - [command] contient le verbe canonique et l'identifiant de destination.
+  /// - [current] est l'état de jeu courant.
+  ///
+  /// Retourne un [TurnResult] avec le nouvel état et la description du lieu
+  /// d'arrivée. Lève un [StateError] si aucune règle ne correspond.
+  Future<TurnResult> call(Command command, Game current) async {
+    final destId = int.tryParse(command.target ?? '');
+    if (destId == null) {
+      throw StateError('Invalid destination id: ${command.target}');
+    }
+
+    final rules = await _repo.travelRulesFor(current.loc);
+    final destLoc = await _repo.locationById(destId);
+
+    for (final r in rules) {
+      final canonical = _motion.toCanonical(r.motion);
+      if (canonical == command.verb && r.destName == destLoc.name) {
+        final newGame = current.copyWith(
+          loc: destId,
+          turns: current.turns + 1,
+        );
+        final desc = destLoc.longDescription?.isNotEmpty == true
+            ? destLoc.longDescription!
+            : destLoc.shortDescription ?? '';
+        return TurnResult(newGame, [desc]);
+      }
+    }
+
+    throw StateError(
+        'No travel rule for ${command.verb} to ${destLoc.name} from ${current.loc}');
+  }
+}
+

--- a/test/domain/usecases/apply_turn_goto_test.dart
+++ b/test/domain/usecases/apply_turn_goto_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:open_adventure/data/repositories/adventure_repository_impl.dart';
+import 'package:open_adventure/data/services/motion_normalizer_impl.dart';
+import 'package:open_adventure/domain/entities/game.dart';
+import 'package:open_adventure/domain/usecases/apply_turn_goto.dart';
+import 'package:open_adventure/domain/value_objects/command.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ApplyTurnGoto', () {
+    test('updates location, increments turns and returns description', () async {
+      final repo = AdventureRepositoryImpl();
+      final motion = MotionNormalizerImpl();
+      final usecase = ApplyTurnGoto(repo, motion);
+      const game = Game(loc: 1, turns: 0, rngSeed: 42);
+      final cmd = Command(verb: 'WEST', target: '2');
+      final result = await usecase(cmd, game);
+      expect(result.newGame.loc, 2);
+      expect(result.newGame.turns, 1);
+      final dest = await repo.locationById(2);
+      final expectedDesc = dest.longDescription ?? dest.shortDescription ?? '';
+      expect(result.messages, [expectedDesc]);
+    });
+
+    test('throws StateError when no matching rule', () async {
+      final repo = AdventureRepositoryImpl();
+      final motion = MotionNormalizerImpl();
+      final usecase = ApplyTurnGoto(repo, motion);
+      const game = Game(loc: 1, turns: 0, rngSeed: 42);
+      final cmd = Command(verb: 'FOO', target: '2');
+      expect(() => usecase(cmd, game), throwsA(isA<StateError>()));
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- add ApplyTurnGoto use case to move between locations and emit descriptions
- cover ApplyTurnGoto with unit tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c80f1593e48327a6d235d6cdf178b5