### PR TITLE
feat: add goto turn application

### DIFF
--- a/lib/data/repositories/adventure_repository_impl.dart
+++ b/lib/data/repositories/adventure_repository_impl.dart
@@ -125,7 +125,13 @@ class AdventureRepositoryImpl implements AdventureRepository {
     if (startId < 0 || startId >= locations.length) {
       startId = 0;
     }
-    return Game(loc: startId, turns: 0, rngSeed: seed);
+    return Game(
+      loc: startId,
+      oldLoc: startId,
+      newLoc: startId,
+      turns: 0,
+      rngSeed: seed,
+    );
   }
 }
 

--- a/lib/domain/entities/game.dart
+++ b/lib/domain/entities/game.dart
@@ -3,6 +3,12 @@ class Game {
   /// Current location id (index in `locations.json`).
   final int loc;
 
+  /// Previous location id before the last move.
+  final int oldLoc;
+
+  /// Location id the player is moving to (mirrors [loc] post-move).
+  final int newLoc;
+
   /// Number of turns elapsed since start.
   final int turns;
 
@@ -12,13 +18,24 @@ class Game {
   /// Creates an immutable Game state.
   const Game({
     required this.loc,
+    required this.oldLoc,
+    required this.newLoc,
     required this.turns,
     required this.rngSeed,
   });
 
   /// Returns a copy with updated fields.
-  Game copyWith({int? loc, int? turns, int? rngSeed}) => Game(
+  Game copyWith({
+    int? loc,
+    int? oldLoc,
+    int? newLoc,
+    int? turns,
+    int? rngSeed,
+  }) =>
+      Game(
         loc: loc ?? this.loc,
+        oldLoc: oldLoc ?? this.oldLoc,
+        newLoc: newLoc ?? this.newLoc,
         turns: turns ?? this.turns,
         rngSeed: rngSeed ?? this.rngSeed,
       );

--- a/lib/domain/usecases/apply_turn_goto.dart
+++ b/lib/domain/usecases/apply_turn_goto.dart
@@ -1,0 +1,54 @@
+import 'package:open_adventure/domain/entities/game.dart';
+import 'package:open_adventure/domain/repositories/adventure_repository.dart';
+import 'package:open_adventure/domain/services/motion_canonicalizer.dart';
+import 'package:open_adventure/domain/value_objects/command.dart';
+import 'package:open_adventure/domain/value_objects/turn_result.dart';
+
+/// ApplyTurnGoto — applique une commande de déplacement `goto`.
+///
+/// Recherche une règle de voyage correspondant au verbe canonique et à la
+/// destination indiquée, puis met à jour l'état de jeu en conséquence.
+class ApplyTurnGoto {
+  final AdventureRepository _repo;
+  final MotionCanonicalizer _motion;
+
+  /// Crée un use case [`ApplyTurnGoto`].
+  const ApplyTurnGoto(this._repo, this._motion);
+
+  /// Applique un déplacement vers une destination.
+  ///
+  /// - [command] contient le verbe canonique et l'identifiant de destination.
+  /// - [current] est l'état de jeu courant.
+  ///
+  /// Retourne un [TurnResult] avec le nouvel état et la description du lieu
+  /// d'arrivée. Lève un [StateError] si aucune règle ne correspond.
+  Future<TurnResult> call(Command command, Game current) async {
+    final destId = int.tryParse(command.target ?? '');
+    if (destId == null) {
+      throw StateError('Invalid destination id: ${command.target}');
+    }
+    final verb = _motion.toCanonical(command.verb);
+    final rules = await _repo.travelRulesFor(current.loc);
+    final destLoc = await _repo.locationById(destId);
+
+    for (final r in rules) {
+      final canonical = _motion.toCanonical(r.motion);
+      if (canonical == verb && r.destName == destLoc.name) {
+        final newGame = current.copyWith(
+          oldLoc: current.loc,
+          loc: destId,
+          newLoc: destId,
+          turns: current.turns + 1,
+        );
+        final desc = destLoc.longDescription?.isNotEmpty == true
+            ? destLoc.longDescription!
+            : destLoc.shortDescription ?? '';
+        return TurnResult(newGame, [desc]);
+      }
+    }
+
+    throw StateError(
+        'No travel rule for ${command.verb} to ${destLoc.name} from ${current.loc}');
+  }
+}
+

--- a/test/domain/initial_game_test.dart
+++ b/test/domain/initial_game_test.dart
@@ -11,6 +11,8 @@ void main() {
     expect(game.rngSeed, 42);
     expect(game.turns, 0);
     expect(game.loc, inInclusiveRange(0, locs.length - 1));
+    expect(game.oldLoc, game.loc);
+    expect(game.newLoc, game.loc);
   });
 }
 

--- a/test/domain/usecases/apply_turn_goto_test.dart
+++ b/test/domain/usecases/apply_turn_goto_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:open_adventure/data/repositories/adventure_repository_impl.dart';
+import 'package:open_adventure/data/services/motion_normalizer_impl.dart';
+import 'package:open_adventure/domain/entities/game.dart';
+import 'package:open_adventure/domain/usecases/apply_turn_goto.dart';
+import 'package:open_adventure/domain/value_objects/command.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ApplyTurnGoto', () {
+    test('updates location, increments turns and returns description', () async {
+      final repo = AdventureRepositoryImpl();
+      final motion = MotionNormalizerImpl();
+      final usecase = ApplyTurnGoto(repo, motion);
+      const game = Game(loc: 1, oldLoc: 1, newLoc: 1, turns: 0, rngSeed: 42);
+      final cmd = Command(verb: 'WEST', target: '2');
+      final result = await usecase(cmd, game);
+      expect(result.newGame.loc, 2);
+      expect(result.newGame.oldLoc, 1);
+      expect(result.newGame.newLoc, 2);
+      expect(result.newGame.turns, 1);
+      final dest = await repo.locationById(2);
+      final expectedDesc = dest.longDescription ?? dest.shortDescription ?? '';
+      expect(result.messages, [expectedDesc]);
+    });
+
+    test('canonicalizes command verb aliases', () async {
+      final repo = AdventureRepositoryImpl();
+      final motion = MotionNormalizerImpl();
+      final usecase = ApplyTurnGoto(repo, motion);
+      const game = Game(loc: 1, oldLoc: 1, newLoc: 1, turns: 0, rngSeed: 42);
+      // MOT_2 is an alias for WEST in the motion table.
+      final cmd = Command(verb: 'MOT_2', target: '2');
+      final result = await usecase(cmd, game);
+      expect(result.newGame.loc, 2);
+    });
+
+    test('throws StateError when no matching rule', () async {
+      final repo = AdventureRepositoryImpl();
+      final motion = MotionNormalizerImpl();
+      final usecase = ApplyTurnGoto(repo, motion);
+      const game = Game(loc: 1, oldLoc: 1, newLoc: 1, turns: 0, rngSeed: 42);
+      final cmd = Command(verb: 'FOO', target: '2');
+      expect(() => usecase(cmd, game), throwsA(isA<StateError>()));
+    });
+  });
+}
+

--- a/test/domain/usecases/list_available_actions_travel_test.dart
+++ b/test/domain/usecases/list_available_actions_travel_test.dart
@@ -12,7 +12,7 @@ void main() {
     final motion = MotionNormalizerImpl();
     final usecase = ListAvailableActionsTravel(repo, motion);
     // Start from LOC_START (id 1) per assets; ensure deterministic seed not needed here
-    const game = Game(loc: 1, turns: 0, rngSeed: 42);
+    const game = Game(loc: 1, oldLoc: 1, newLoc: 1, turns: 0, rngSeed: 42);
     final opts = await usecase(game);
     expect(opts, isNotEmpty);
     // Only travel
@@ -38,7 +38,7 @@ void main() {
     final repo = AdventureRepositoryImpl();
     final motion = MotionNormalizerImpl();
     final usecase = ListAvailableActionsTravel(repo, motion);
-    const game = Game(loc: 1, turns: 0, rngSeed: 42);
+    const game = Game(loc: 1, oldLoc: 1, newLoc: 1, turns: 0, rngSeed: 42);
     final opts = await usecase(game);
     // If both MOT_2 and WEST exist in travel.json for LOC_START, they must dedupe to one WEST option.
     final westOpts = opts.where((o) => o.verb == 'WEST').toList();
@@ -49,7 +49,7 @@ void main() {
     final repo = AdventureRepositoryImpl();
     final motion = MotionNormalizerImpl();
     final usecase = ListAvailableActionsTravel(repo, motion);
-    const game = Game(loc: 1, turns: 0, rngSeed: 42);
+    const game = Game(loc: 1, oldLoc: 1, newLoc: 1, turns: 0, rngSeed: 42);
     final opts = await usecase(game);
     for (final o in opts) {
       expect(o.label.startsWith('motion.'), isTrue);
@@ -63,7 +63,7 @@ void main() {
     final repo = AdventureRepositoryImpl();
     final motion = MotionNormalizerImpl();
     final usecase = ListAvailableActionsTravel(repo, motion);
-    const game = Game(loc: 1, turns: 0, rngSeed: 42);
+    const game = Game(loc: 1, oldLoc: 1, newLoc: 1, turns: 0, rngSeed: 42);
     final opts = await usecase(game);
     for (final o in opts) {
       expect(o.id.startsWith('travel:1->'), isTrue);

--- a/test/domain/value_objects/turn_result_test.dart
+++ b/test/domain/value_objects/turn_result_test.dart
@@ -5,8 +5,8 @@ import 'package:open_adventure/domain/value_objects/turn_result.dart';
 void main() {
   group('TurnResult', () {
     test('is immutable and value-equal', () {
-      const g1 = Game(loc: 1, turns: 0, rngSeed: 42);
-      const g2 = Game(loc: 1, turns: 0, rngSeed: 42);
+      const g1 = Game(loc: 1, oldLoc: 1, newLoc: 1, turns: 0, rngSeed: 42);
+      const g2 = Game(loc: 1, oldLoc: 1, newLoc: 1, turns: 0, rngSeed: 42);
       final r1 = TurnResult(g1, ['hello', 'world']);
       final r2 = TurnResult(g2, ['hello', 'world']);
       final r3 = TurnResult(g2, ['another']);


### PR DESCRIPTION
## Summary
- add ApplyTurnGoto use case to move between locations and emit descriptions
- track previous and next location in Game state
- cover ApplyTurnGoto and Game with unit tests
- canonicalize goto command verbs to accept motion aliases

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test test/domain/usecases/apply_turn_goto_test.dart test/domain/value_objects/turn_result_test.dart test/domain/initial_game_test.dart test/domain/usecases/list_available_actions_travel_test.dart test/data/repositories/adventure_repository_impl_metadata_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c80f1593e48327a6d235d6cdf178b5