### PR TITLE
Fix meta action accent token availability

### DIFF
--- a/docs/VISUAL_STYLE_GUIDE.md
+++ b/docs/VISUAL_STYLE_GUIDE.md
@@ -57,6 +57,10 @@ Catégories d’actions (accents)
 - `action.interaction` = Light : #1565C0 | Dark : #64B5F6
 - `action.meta`        = Light : #616161 | Dark : #9E9E9E
 
+> Implémentation Flutter : `ThemeData` expose l’extension `AppActionAccents`
+> (travel/interaction/meta) pour fournir ces tokens de manière typée à tous les
+> widgets de présentation.
+
 Lampe — seuils batterie (StatusBar)
 
 - >50%: #4CAF50 | 20–50%: #ED6C02 | <20%: #D32F2F

--- a/lib/presentation/pages/home/widgets/home_hero_banner.dart
+++ b/lib/presentation/pages/home/widgets/home_hero_banner.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:open_adventure/presentation/theme/app_spacing.dart';
+import 'package:open_adventure/presentation/widgets/pixel_canvas.dart';
+
+/// Displays the hero pixel art banner rendered inside the pixel canvas.
+class HomeHeroBanner extends StatelessWidget {
+  /// Creates a [HomeHeroBanner] ready to paint the cavern illustration.
+  const HomeHeroBanner({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final scheme = Theme.of(context).colorScheme;
+    return AspectRatio(
+      aspectRatio: 16 / 9,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          PixelCanvas(
+            child: CustomPaint(
+              painter: _HomeHeroPixelArtPainter(
+                scheme: scheme,
+              ),
+            ),
+          ),
+          DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  Colors.transparent,
+                  Colors.black.withValues(alpha: 0.55),
+                ],
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(AppSpacing.lg),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.end,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Open Adventure',
+                  style: textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                Text(
+                  'Partez pour l\'expédition textuelle culte, remasterisée pour mobile.',
+                  style: textTheme.bodyMedium?.copyWith(
+                    color: Colors.white.withValues(alpha: 0.85),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HomeHeroPixelArtPainter extends CustomPainter {
+  _HomeHeroPixelArtPainter({required this.scheme});
+
+  final ColorScheme scheme;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const double unit = 4;
+    final Paint paint = Paint()..isAntiAlias = false;
+
+    void draw(double x, double y, double w, double h, Color color) {
+      paint.color = color;
+      canvas.drawRect(
+        Rect.fromLTWH(x * unit, y * unit, w * unit, h * unit),
+        paint,
+      );
+    }
+
+    // Background cavern gradient blocks.
+    draw(0, 0, 80, 45, const Color(0xFF0B0D16));
+    draw(0, 0, 80, 18, const Color(0xFF11162A));
+    draw(0, 18, 80, 12, const Color(0xFF151D34));
+    draw(0, 30, 80, 8, const Color(0xFF1C223A));
+    draw(0, 38, 80, 7, const Color(0xFF0B0D16));
+
+    // Cave walls and stalactites.
+    draw(4, 4, 6, 14, const Color(0xFF2D223D));
+    draw(10, 2, 8, 16, const Color(0xFF372B4C));
+    draw(26, 1, 6, 20, const Color(0xFF2A203B));
+    draw(36, 3, 6, 22, const Color(0xFF433359));
+    draw(50, 2, 7, 18, const Color(0xFF2F2343));
+    draw(60, 5, 6, 16, const Color(0xFF3B2D4F));
+    draw(68, 6, 5, 12, const Color(0xFF2A1F39));
+
+    // Floor stones.
+    draw(0, 42, 12, 3, const Color(0xFF3C2E44));
+    draw(12, 41, 10, 4, const Color(0xFF4A3955));
+    draw(24, 40, 14, 5, const Color(0xFF3A2B4E));
+    draw(40, 41, 12, 4, const Color(0xFF4F3A5C));
+    draw(52, 42, 10, 3, const Color(0xFF3B2B48));
+    draw(62, 41, 18, 4, const Color(0xFF34203F));
+
+    // Torch and light glow near entrance.
+    final Color torchBase = const Color(0xFF5D3A1F);
+    final Color torchFlame = const Color(0xFFFFB547);
+    draw(20, 20, 2, 10, torchBase);
+    draw(20, 18, 2, 2, torchFlame);
+    draw(19, 21, 4, 4, torchFlame.withValues(alpha: 0.6));
+
+    // Entrance arch with subtle highlight influenced by theme primary/secondary.
+    final Color highlight = Color.alphaBlend(
+      scheme.secondary.withValues(alpha: 0.35),
+      const Color(0xFF2E243E),
+    );
+    draw(44, 18, 14, 14, highlight);
+    draw(48, 22, 6, 10, const Color(0xFF120F1F));
+
+    // Foreground silhouette framing bottom corners.
+    draw(0, 36, 6, 9, const Color(0xFF07060D));
+    draw(74, 34, 6, 11, const Color(0xFF07060D));
+  }
+
+  @override
+  bool shouldRepaint(covariant _HomeHeroPixelArtPainter oldDelegate) {
+    return oldDelegate.scheme != scheme;
+  }
+}

--- a/lib/presentation/pages/home/widgets/home_menu_button.dart
+++ b/lib/presentation/pages/home/widgets/home_menu_button.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:open_adventure/presentation/theme/app_spacing.dart';
+
+/// A primary action button displayed in the home menu.
+class HomeMenuButton extends StatelessWidget {
+  /// Creates a [HomeMenuButton] with a title, subtitle and accent styling.
+  const HomeMenuButton({
+    super.key,
+    required this.label,
+    required this.subtitle,
+    required this.icon,
+    this.accentColor,
+    this.showAccentStripe = true,
+    required this.onPressed,
+  });
+
+  /// Main button label.
+  final String label;
+
+  /// Supporting description displayed under [label].
+  final String subtitle;
+
+  /// Icon representing the action category.
+  final IconData icon;
+
+  /// Optional accent tint applied to the stripe and icon.
+  final Color? accentColor;
+
+  /// Controls whether the accent stripe is painted on the left side.
+  final bool showAccentStripe;
+
+  /// Callback triggered when the button is pressed.
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final enabled = onPressed != null;
+    final Color backgroundColor = enabled
+        ? scheme.surface
+        : scheme.onSurface.withValues(alpha: 0.12);
+    final bool hasAccent = accentColor != null;
+    final Color? baseAccent = accentColor;
+    final Color accentForState = hasAccent
+        ? (enabled
+            ? baseAccent!
+            : baseAccent!.withValues(alpha: 0.3))
+        : Colors.transparent;
+    final Color iconColor = hasAccent
+        ? accentForState
+        : (enabled
+            ? scheme.onSurface
+            : scheme.onSurface.withValues(alpha: 0.3));
+    final Color labelColor = enabled
+        ? scheme.onSurface
+        : scheme.onSurface.withValues(alpha: 0.38);
+    final Color subtitleColor = enabled
+        ? scheme.onSurfaceVariant
+        : scheme.onSurface.withValues(alpha: 0.38);
+    return Semantics(
+      button: true,
+      enabled: enabled,
+      label: label,
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: BorderRadius.circular(16),
+        child: Ink(
+          decoration: BoxDecoration(
+            color: backgroundColor,
+            borderRadius: BorderRadius.circular(16),
+            boxShadow: [
+              BoxShadow(
+                color: scheme.shadow.withValues(alpha: 0.08),
+                offset: const Offset(0, 4),
+                blurRadius: 12,
+              ),
+            ],
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Container(
+                  key: ValueKey('homeMenuAccent-$label'),
+                  width: 4,
+                  height: 56,
+                  decoration: BoxDecoration(
+                    color: showAccentStripe ? accentForState : Colors.transparent,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.md),
+                Icon(
+                  icon,
+                  size: 24,
+                  color: iconColor,
+                ),
+                const SizedBox(width: AppSpacing.lg),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        label,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                          color: labelColor,
+                        ),
+                      ),
+                      const SizedBox(height: AppSpacing.xs / 2),
+                      Text(
+                        subtitle,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: subtitleColor,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -4,10 +4,12 @@ import 'package:open_adventure/application/controllers/game_controller.dart';
 import 'package:open_adventure/application/controllers/home_controller.dart';
 import 'package:open_adventure/presentation/pages/adventure_page.dart';
 import 'package:open_adventure/presentation/pages/credits_page.dart';
+import 'package:open_adventure/presentation/pages/home/widgets/home_hero_banner.dart';
+import 'package:open_adventure/presentation/pages/home/widgets/home_menu_button.dart';
 import 'package:open_adventure/presentation/pages/saves_page.dart';
 import 'package:open_adventure/presentation/pages/settings_page.dart';
+import 'package:open_adventure/presentation/theme/app_colors.dart';
 import 'package:open_adventure/presentation/theme/app_spacing.dart';
-import 'package:open_adventure/presentation/widgets/pixel_canvas.dart';
 
 /// HomePage v0 — presents the entry menu for starting or resuming the adventure.
 class HomePage extends StatefulWidget {
@@ -101,13 +103,20 @@ class _HomePageState extends State<HomePage> {
               builder: (context, constraints) {
                 final verticalPadding =
                     constraints.maxHeight > 600 ? AppSpacing.xl : AppSpacing.lg;
+                final theme = Theme.of(context);
+                final scheme = theme.colorScheme;
+                final AppActionAccents accents =
+                    theme.extension<AppActionAccents>()!;
+
+                final menuConfigurations =
+                    _menuConfigurations(state, scheme, accents);
 
                 return SingleChildScrollView(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
                       SizedBox(height: verticalPadding),
-                      const _HeroBanner(),
+                      const HomeHeroBanner(),
                       const SizedBox(height: AppSpacing.xl),
                       Padding(
                         padding: const EdgeInsets.symmetric(
@@ -119,59 +128,7 @@ class _HomePageState extends State<HomePage> {
                             constraints: const BoxConstraints(maxWidth: 560),
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.stretch,
-                              children: [
-                                _PrimaryMenuButton(
-                                  label: 'Nouvelle partie',
-                                  subtitle:
-                                      'Commencer l\'exploration de la caverne',
-                                  icon: Icons.play_arrow_rounded,
-                                  accentColor:
-                                      Theme.of(context).colorScheme.primary,
-                                  onPressed: _openAdventure,
-                                ),
-                                const SizedBox(height: AppSpacing.md),
-                                _PrimaryMenuButton(
-                                  label: 'Continuer',
-                                  subtitle: state.autosave != null
-                                      ? 'Dernier tour : ${state.autosave!.turns}, lieu #${state.autosave!.loc}'
-                                      : 'Aucune sauvegarde automatique détectée',
-                                  icon: Icons.history_rounded,
-                                  accentColor:
-                                      Theme.of(context).colorScheme.secondary,
-                                  onPressed:
-                                      state.autosave != null ? _openAdventure : null,
-                                ),
-                                const SizedBox(height: AppSpacing.md),
-                                _PrimaryMenuButton(
-                                  label: 'Charger',
-                                  subtitle: 'Accéder aux sauvegardes manuelles',
-                                  icon: Icons.folder_open_rounded,
-                                  accentColor:
-                                      Theme.of(context).colorScheme.tertiary,
-                                  onPressed: _openSaves,
-                                ),
-                                const SizedBox(height: AppSpacing.md),
-                                _PrimaryMenuButton(
-                                  label: 'Options',
-                                  subtitle:
-                                      'Configurer l\'expérience audio et tactile',
-                                  icon: Icons.tune_rounded,
-                                  accentColor:
-                                      _metaAccent(Theme.of(context).brightness),
-                                  showAccentStripe: false,
-                                  onPressed: _openSettings,
-                                ),
-                                const SizedBox(height: AppSpacing.md),
-                                _PrimaryMenuButton(
-                                  label: 'Crédits',
-                                  subtitle: 'L\'équipe derrière cette aventure',
-                                  icon: Icons.info_outline_rounded,
-                                  accentColor:
-                                      _metaAccent(Theme.of(context).brightness),
-                                  showAccentStripe: false,
-                                  onPressed: _openCredits,
-                                ),
-                              ],
+                              children: _buildMenu(menuConfigurations),
                             ),
                           ),
                         ),
@@ -187,142 +144,83 @@ class _HomePageState extends State<HomePage> {
       ),
     );
   }
-}
 
-class _HeroBanner extends StatelessWidget {
-  const _HeroBanner();
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    final scheme = Theme.of(context).colorScheme;
-    return AspectRatio(
-      aspectRatio: 16 / 9,
-      child: Stack(
-        fit: StackFit.expand,
-        children: [
-          PixelCanvas(
-            child: CustomPaint(
-              painter: _HeroPixelArtPainter(
-                scheme: scheme,
-              ),
-            ),
-          ),
-          DecoratedBox(
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
-                colors: [
-                  Colors.transparent,
-                  Colors.black.withValues(alpha: 0.55),
-                ],
-              ),
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.all(AppSpacing.lg),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.end,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Open Adventure',
-                  style: textTheme.headlineSmall?.copyWith(
-                    fontWeight: FontWeight.bold,
-                    color: Colors.white,
-                  ),
-                ),
-                const SizedBox(height: AppSpacing.sm),
-                Text(
-                  'Partez pour l\'expédition textuelle culte, remasterisée pour mobile.',
-                  style: textTheme.bodyMedium?.copyWith(
-                    color: Colors.white.withValues(alpha: 0.85),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
+  List<_MenuConfiguration> _menuConfigurations(
+    HomeViewState state,
+    ColorScheme scheme,
+    AppActionAccents accents,
+  ) {
+    return [
+      _MenuConfiguration(
+        label: 'Nouvelle partie',
+        subtitle: 'Commencer l\'exploration de la caverne',
+        icon: Icons.play_arrow_rounded,
+        accentColor: scheme.primary,
+        onPressed: _openAdventure,
       ),
-    );
+      _MenuConfiguration(
+        label: 'Continuer',
+        subtitle: state.autosave != null
+            ? 'Dernier tour : ${state.autosave!.turns}, lieu #${state.autosave!.loc}'
+            : 'Aucune sauvegarde automatique détectée',
+        icon: Icons.history_rounded,
+        accentColor: scheme.secondary,
+        onPressed: state.autosave != null ? _openAdventure : null,
+      ),
+      _MenuConfiguration(
+        label: 'Charger',
+        subtitle: 'Accéder aux sauvegardes manuelles',
+        icon: Icons.folder_open_rounded,
+        accentColor: scheme.tertiary,
+        onPressed: _openSaves,
+      ),
+      _MenuConfiguration(
+        label: 'Options',
+        subtitle: 'Configurer l\'expérience audio et tactile',
+        icon: Icons.tune_rounded,
+        accentColor: accents.meta,
+        showAccentStripe: false,
+        onPressed: _openSettings,
+      ),
+      _MenuConfiguration(
+        label: 'Crédits',
+        subtitle: 'L\'équipe derrière cette aventure',
+        icon: Icons.info_outline_rounded,
+        accentColor: accents.meta,
+        showAccentStripe: false,
+        onPressed: _openCredits,
+      ),
+    ];
   }
-}
 
-class _HeroPixelArtPainter extends CustomPainter {
-  _HeroPixelArtPainter({required this.scheme});
-
-  final ColorScheme scheme;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    const double unit = 4;
-    final Paint paint = Paint()..isAntiAlias = false;
-
-    void draw(double x, double y, double w, double h, Color color) {
-      paint.color = color;
-      canvas.drawRect(
-        Rect.fromLTWH(x * unit, y * unit, w * unit, h * unit),
-        paint,
+  List<Widget> _buildMenu(List<_MenuConfiguration> configurations) {
+    final widgets = <Widget>[];
+    for (var i = 0; i < configurations.length; i++) {
+      final configuration = configurations[i];
+      widgets.add(
+        HomeMenuButton(
+          label: configuration.label,
+          subtitle: configuration.subtitle,
+          icon: configuration.icon,
+          accentColor: configuration.accentColor,
+          showAccentStripe: configuration.showAccentStripe,
+          onPressed: configuration.onPressed,
+        ),
       );
+      if (i < configurations.length - 1) {
+        widgets.add(const SizedBox(height: AppSpacing.md));
+      }
     }
-
-    // Background cavern gradient blocks.
-    draw(0, 0, 80, 45, const Color(0xFF0B0D16));
-    draw(0, 0, 80, 18, const Color(0xFF11162A));
-    draw(0, 18, 80, 12, const Color(0xFF151D34));
-    draw(0, 30, 80, 8, const Color(0xFF1C223A));
-    draw(0, 38, 80, 7, const Color(0xFF0B0D16));
-
-    // Cave walls and stalactites.
-    draw(4, 4, 6, 14, const Color(0xFF2D223D));
-    draw(10, 2, 8, 16, const Color(0xFF372B4C));
-    draw(26, 1, 6, 20, const Color(0xFF2A203B));
-    draw(36, 3, 6, 22, const Color(0xFF433359));
-    draw(50, 2, 7, 18, const Color(0xFF2F2343));
-    draw(60, 5, 6, 16, const Color(0xFF3B2D4F));
-    draw(68, 6, 5, 12, const Color(0xFF2A1F39));
-
-    // Floor stones.
-    draw(0, 42, 12, 3, const Color(0xFF3C2E44));
-    draw(12, 41, 10, 4, const Color(0xFF4A3955));
-    draw(24, 40, 14, 5, const Color(0xFF3A2B4E));
-    draw(40, 41, 12, 4, const Color(0xFF4F3A5C));
-    draw(52, 42, 10, 3, const Color(0xFF3B2B48));
-    draw(62, 41, 18, 4, const Color(0xFF34203F));
-
-    // Torch and light glow near entrance.
-    final Color torchBase = const Color(0xFF5D3A1F);
-    final Color torchFlame = const Color(0xFFFFB547);
-    draw(20, 20, 2, 10, torchBase);
-    draw(20, 18, 2, 2, torchFlame);
-    draw(19, 21, 4, 4, torchFlame.withValues(alpha: 0.6));
-
-    // Entrance arch with subtle highlight influenced by theme primary/secondary.
-    final Color highlight = Color.alphaBlend(
-      scheme.secondary.withValues(alpha: 0.35),
-      const Color(0xFF2E243E),
-    );
-    draw(44, 18, 14, 14, highlight);
-    draw(48, 22, 6, 10, const Color(0xFF120F1F));
-
-    // Foreground silhouette framing bottom corners.
-    draw(0, 36, 6, 9, const Color(0xFF07060D));
-    draw(74, 34, 6, 11, const Color(0xFF07060D));
-  }
-
-  @override
-  bool shouldRepaint(covariant _HeroPixelArtPainter oldDelegate) {
-    return oldDelegate.scheme != scheme;
+    return widgets;
   }
 }
 
-class _PrimaryMenuButton extends StatelessWidget {
-  const _PrimaryMenuButton({
+class _MenuConfiguration {
+  _MenuConfiguration({
     required this.label,
     required this.subtitle,
     required this.icon,
-    this.accentColor,
+    required this.accentColor,
     this.showAccentStripe = true,
     required this.onPressed,
   });
@@ -331,109 +229,6 @@ class _PrimaryMenuButton extends StatelessWidget {
   final String subtitle;
   final IconData icon;
   final Color? accentColor;
-  /// Controls whether the accent stripe is painted on the left side.
   final bool showAccentStripe;
   final VoidCallback? onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
-    final enabled = onPressed != null;
-    final Color backgroundColor = enabled
-        ? scheme.surface
-        : scheme.onSurface.withValues(alpha: 0.12);
-    final bool hasAccent = accentColor != null;
-    final Color? baseAccent = accentColor;
-    final Color accentForState = hasAccent
-        ? (enabled
-            ? baseAccent!
-            : baseAccent!.withValues(alpha: 0.3))
-        : Colors.transparent;
-    final Color iconColor = hasAccent
-        ? accentForState
-        : (enabled
-            ? scheme.onSurface
-            : scheme.onSurface.withValues(alpha: 0.3));
-    final Color labelColor = enabled
-        ? scheme.onSurface
-        : scheme.onSurface.withValues(alpha: 0.38);
-    final Color subtitleColor = enabled
-        ? scheme.onSurfaceVariant
-        : scheme.onSurface.withValues(alpha: 0.38);
-    return Semantics(
-      button: true,
-      enabled: enabled,
-      label: label,
-      child: InkWell(
-        onTap: onPressed,
-        borderRadius: BorderRadius.circular(16),
-        child: Ink(
-          decoration: BoxDecoration(
-            color: backgroundColor,
-            borderRadius: BorderRadius.circular(16),
-            boxShadow: [
-              BoxShadow(
-                color: scheme.shadow.withValues(alpha: 0.08),
-                offset: const Offset(0, 4),
-                blurRadius: 12,
-              ),
-            ],
-          ),
-          child: Padding(
-            padding: const EdgeInsets.all(AppSpacing.md),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Container(
-                  key: ValueKey('homeMenuAccent-$label'),
-                  width: 4,
-                  height: 56,
-                  decoration: BoxDecoration(
-                    color:
-                        showAccentStripe ? accentForState : Colors.transparent,
-                    borderRadius: BorderRadius.circular(4),
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.md),
-                Icon(
-                  icon,
-                  size: 24,
-                  color: iconColor,
-                ),
-                const SizedBox(width: AppSpacing.lg),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        label,
-                        style: theme.textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: labelColor,
-                        ),
-                      ),
-                      const SizedBox(height: AppSpacing.xs / 2),
-                      Text(
-                        subtitle,
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: subtitleColor,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-Color _metaAccent(Brightness brightness) {
-  return brightness == Brightness.dark
-      ? const Color(0xFF9E9E9E)
-      : const Color(0xFF616161);
 }

--- a/lib/presentation/theme/app_colors.dart
+++ b/lib/presentation/theme/app_colors.dart
@@ -82,3 +82,65 @@ class AppColorSchemes {
     surfaceTint: Color(0xFF8C88FF),
   );
 }
+
+/// Provides categorical accent colors for travel, interaction and meta actions
+/// as mandated by the visual style guide. Exposed as a [ThemeExtension] so
+/// presentation widgets can retrieve consistent hues regardless of the active
+/// brightness.
+@immutable
+class AppActionAccents extends ThemeExtension<AppActionAccents> {
+  /// Creates a set of action accent colors.
+  const AppActionAccents({
+    required this.travel,
+    required this.interaction,
+    required this.meta,
+  });
+
+  /// Accent used for travel actions (movement between locations).
+  final Color travel;
+
+  /// Accent used for interaction actions (manipulating the environment).
+  final Color interaction;
+
+  /// Accent used for meta actions (UI, options, journal, saves...).
+  final Color meta;
+
+  /// Light theme accents defined by the visual style guide tokens.
+  static const AppActionAccents light = AppActionAccents(
+    travel: Color(0xFF2E7D32),
+    interaction: Color(0xFF0288D1),
+    meta: Color(0xFF616161),
+  );
+
+  /// Dark theme accents defined by the visual style guide tokens.
+  static const AppActionAccents dark = AppActionAccents(
+    travel: Color(0xFF81C784),
+    interaction: Color(0xFF64B5F6),
+    meta: Color(0xFF9E9E9E),
+  );
+
+  @override
+  AppActionAccents copyWith({
+    Color? travel,
+    Color? interaction,
+    Color? meta,
+  }) {
+    return AppActionAccents(
+      travel: travel ?? this.travel,
+      interaction: interaction ?? this.interaction,
+      meta: meta ?? this.meta,
+    );
+  }
+
+  @override
+  AppActionAccents lerp(AppActionAccents? other, double t) {
+    if (other == null) {
+      return this;
+    }
+    return AppActionAccents(
+      travel: Color.lerp(travel, other.travel, t) ?? travel,
+      interaction: Color.lerp(interaction, other.interaction, t) ?? interaction,
+      meta: Color.lerp(meta, other.meta, t) ?? meta,
+    );
+  }
+}

--- a/lib/presentation/theme/app_theme.dart
+++ b/lib/presentation/theme/app_theme.dart
@@ -21,6 +21,11 @@ class AppTheme {
       colorScheme: scheme,
       scaffoldBackgroundColor: scheme.surface,
       textTheme: textTheme,
+      extensions: <ThemeExtension<dynamic>>[
+        scheme.brightness == Brightness.dark
+            ? AppActionAccents.dark
+            : AppActionAccents.light,
+      ],
       appBarTheme: AppBarTheme(
         backgroundColor: scheme.surface,
         surfaceTintColor: Colors.transparent,

--- a/test/presentation/pages/home_page_test.dart
+++ b/test/presentation/pages/home_page_test.dart
@@ -23,6 +23,7 @@ import 'package:open_adventure/presentation/pages/credits_page.dart';
 import 'package:open_adventure/presentation/pages/home_page.dart';
 import 'package:open_adventure/presentation/pages/saves_page.dart';
 import 'package:open_adventure/presentation/pages/settings_page.dart';
+import 'package:open_adventure/presentation/theme/app_colors.dart';
 import 'package:open_adventure/presentation/theme/app_theme.dart';
 import 'package:open_adventure/presentation/widgets/pixel_canvas.dart';
 
@@ -274,8 +275,12 @@ void main() {
           optionsAccent.decoration! as BoxDecoration;
       expect(optionsDecoration.color, Colors.transparent);
 
+      final BuildContext optionsContext = tester.element(find.text('Options'));
+      final AppActionAccents accents =
+          Theme.of(optionsContext).extension<AppActionAccents>()!;
+
       final Icon optionsIcon = tester.widget(find.byIcon(Icons.tune_rounded));
-      expect(optionsIcon.color, const Color(0xFF616161));
+      expect(optionsIcon.color, accents.meta);
 
       final Container creditsAccent = tester.widget(
         find.byKey(const ValueKey('homeMenuAccent-Crédits')),
@@ -286,7 +291,7 @@ void main() {
 
       final Icon creditsIcon =
           tester.widget(find.byIcon(Icons.info_outline_rounded));
-      expect(creditsIcon.color, const Color(0xFF616161));
+      expect(creditsIcon.color, accents.meta);
     });
 
     testWidgets('disabled accent buttons dim surfaces and typography',


### PR DESCRIPTION
## Summary
- add an `AppActionAccents` theme extension carrying travel/interaction/meta hues
- wire the home page to use the canonical meta accent instead of a hard-coded helper
- document the extension in the visual style guide and adjust widget tests accordingly
- refactor the HomePage layout by extracting the hero banner and menu button widgets and centralizing menu configuration data for better readability

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d425b0d7c083279bd16385607825e7