### PR TITLE
fix: hide accent stripes on meta menu items

### DIFF
--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -156,6 +156,7 @@ class _HomePageState extends State<HomePage> {
         subtitle: 'Commencer l\'exploration de la caverne',
         icon: Icons.play_arrow_rounded,
         accentColor: scheme.primary,
+        showAccentStripe: true,
         onPressed: _openAdventure,
       ),
       _MenuConfiguration(
@@ -165,6 +166,7 @@ class _HomePageState extends State<HomePage> {
             : null,
         icon: Icons.bookmark_rounded,
         accentColor: scheme.secondary,
+        showAccentStripe: true,
         onPressed: state.autosave != null ? _openAdventure : null,
       ),
       _MenuConfiguration(
@@ -172,6 +174,7 @@ class _HomePageState extends State<HomePage> {
         subtitle: 'Accéder aux sauvegardes manuelles',
         icon: Icons.folder_open_rounded,
         accentColor: scheme.tertiary,
+        showAccentStripe: true,
         onPressed: _openSaves,
       ),
       _MenuConfiguration(
@@ -179,6 +182,7 @@ class _HomePageState extends State<HomePage> {
         subtitle: 'Configurer l\'expérience audio et tactile',
         icon: Icons.tune_rounded,
         accentColor: accents.meta,
+        showAccentStripe: false,
         onPressed: _openSettings,
       ),
       _MenuConfiguration(
@@ -186,6 +190,7 @@ class _HomePageState extends State<HomePage> {
         subtitle: 'L\'équipe derrière cette aventure',
         icon: Icons.info_outline_rounded,
         accentColor: accents.meta,
+        showAccentStripe: false,
         onPressed: _openCredits,
       ),
     ];
@@ -201,6 +206,7 @@ class _HomePageState extends State<HomePage> {
           subtitle: configuration.subtitle,
           icon: configuration.icon,
           accentColor: configuration.accentColor,
+          showAccentStripe: configuration.showAccentStripe,
           onPressed: configuration.onPressed,
         ),
       );
@@ -218,6 +224,7 @@ class _MenuConfiguration {
     this.subtitle,
     required this.icon,
     required this.accentColor,
+    required this.showAccentStripe,
     required this.onPressed,
   });
 
@@ -225,5 +232,6 @@ class _MenuConfiguration {
   final String? subtitle;
   final IconData icon;
   final Color? accentColor;
+  final bool showAccentStripe;
   final VoidCallback? onPressed;
 }

--- a/test/presentation/pages/home_page_test.dart
+++ b/test/presentation/pages/home_page_test.dart
@@ -283,10 +283,6 @@ void main() {
           optionsAccent.decoration! as BoxDecoration;
       expect(optionsDecoration.color, Colors.transparent);
 
-      final BuildContext optionsContext = tester.element(find.text('Options'));
-      final AppActionAccents accents =
-          Theme.of(optionsContext).extension<AppActionAccents>()!;
-
       final Icon optionsIcon = tester.widget(find.byIcon(Icons.tune_rounded));
       expect(optionsIcon.color, metaAccents.meta);
 


### PR DESCRIPTION
## Summary
- keep Options and Crédits menu entries icon-tinted while hiding their accent stripes
- ensure menu configuration forwards the stripe visibility flag to the button widget
- clean up the unused accent variable in the home page test

## Testing
- flutter analyze *(fails: command not found in environment)*
- flutter test *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5696205a88327a01d8445d3c29802